### PR TITLE
update infra role name

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -73,5 +73,5 @@ runs:
       run: |
         pulumi stack select -c ${{ matrix.stack }}
         pulumi config set aws:skipCredentialsValidation true
-        pulumi ${{ inputs.pulumi-action }} $(if [ ${{ inputs.refresh }} == y]; then echo "--refresh"; fi) $(if [ ${{ inputs.pulumi-action }} = up ];then echo "--yes"; fi)
+        pulumi ${{ inputs.pulumi-action }} $(if [ ${{ inputs.refresh }} == y]; then echo "--refresh"; fi) $(if [ ${{ inputs.pulumi-action }} = up ] || [ ${{ inputs.pulumi-action }} = destroy ] ;then echo "--yes"; fi)
         

--- a/action.yaml
+++ b/action.yaml
@@ -73,5 +73,5 @@ runs:
       run: |
         pulumi stack select -c ${{ matrix.stack }}
         pulumi config set aws:skipCredentialsValidation true
-        pulumi ${{ inputs.pulumi-action }} $(if [ ${{ inputs.refresh }} == y]; then echo "--refresh"; fi) $(if [ ${{ inputs.pulumi-action }} = up ] || [ ${{ inputs.pulumi-action }} = destroy ] ;then echo "--yes"; fi)
+        pulumi ${{ inputs.pulumi-action }} $(if [ ${{ inputs.refresh }} = y]; then echo "--refresh"; fi) $(if [ ${{ inputs.pulumi-action }} = up ] || [ ${{ inputs.pulumi-action }} = destroy ] ;then echo "--yes"; fi)
         

--- a/action.yaml
+++ b/action.yaml
@@ -69,7 +69,7 @@ runs:
       shell: bash
       env:
         PULUMI_CONFIG_PASSPHRASE: ""
-        INFRA_CREATOR_ROLE_NAME: "DataEngineeringGitHubAction"
+        INFRA_CREATOR_ROLE_NAME: "github-actions-infrastructure"
       run: |
         pulumi stack select -c ${{ matrix.stack }}
         pulumi config set aws:skipCredentialsValidation true

--- a/default-aws-config
+++ b/default-aws-config
@@ -1,17 +1,17 @@
 [profile github-actions@data]
 region=eu-west-1
-role_arn=arn:aws:iam::593291632749:role/DataEngineeringGitHubAction
+role_arn=arn:aws:iam::593291632749:role/github-actions-infrastructure
 color=89f462
 credential_source=Environment
 
 [profile github-actions@data-engineering]
 region=eu-west-1
-role_arn=arn:aws:iam::189157455002:role/DataEngineeringGitHubAction
+role_arn=arn:aws:iam::189157455002:role/github-actions-infrastructure
 color=ffcccb
 credential_source=Environment
 
 [profile github-actions@sandbox]
 region=eu-west-1
-role_arn=arn:aws:iam::684969100054:role/DataEngineeringGitHubAction
+role_arn=arn:aws:iam::684969100054:role/github-actions-infrastructure
 color=ffaaee
 credential_source=Environment


### PR DESCRIPTION
https://github.com/ministryofjustice/analytics-platform-infrastructure/issues/958

This makes the action work with the current setup for OIDC roles' assumable deployment role in each account. And since we will soon no longer be able to do pulumi up or destroy locally, have made a small addition so the action can run `pulumi destroy` too